### PR TITLE
Document imodels:read as the only necessary scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ and iModelId with the appropriate values for your iModel.
 You will also need to provide a clientId, scope and redirectUri for your application. To register an application,
 go to [https://developer.bentley.com/register/](https://developer.bentley.com/register/).
 
-- Add "Visualization" and "Digital Twin Management" as API Associations
+- Add "Digital Twin Management" as an API Association to get the "imodels:read" scope
 - Select "Desktop/Mobile" as the Application Type
 - Enter "http://localhost:3000/signin-callback" for Redirect URI
 - No logout URI is required

--- a/node/src/IModelHubDownload.ts
+++ b/node/src/IModelHubDownload.ts
@@ -19,7 +19,7 @@ const AUTH_CLIENT_CONFIG_PROPS = {
   clientId: "", // EDIT ME! Specify your own clientId
 
   /** These are the minimum scopes needed - you can leave alone or replace with your own entries */
-  scope: "email openid profile organization itwinjs imodelaccess:read imodels:read",
+  scope: "imodels:read",
   /** This can be left as-is assuming you've followed the instructions in README.md when registering your application */
   redirectUri: "http://localhost:3000/signin-callback",
 };


### PR DESCRIPTION
With our updated public APIs, scopes like "email userid itwinjs" etc are
no longer necessary for just downloading iModels from iModelHub.